### PR TITLE
Fixes #35: Adds the possibility to select the centre button

### DIFF
--- a/Sample/build.gradle
+++ b/Sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "25.0.1"
     defaultConfig {
         applicationId "com.luseen.spacenavigationview"
         minSdkVersion 14
@@ -24,8 +24,8 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.0.0'
-    compile 'com.android.support:design:25.0.0'
+    compile 'com.android.support:appcompat-v7:25.0.1'
+    compile 'com.android.support:design:25.0.1'
     compile project(':spacelib')
     testCompile 'junit:junit:4.12'
 }

--- a/spacelib/build.gradle
+++ b/spacelib/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.novoda.bintray-release'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         minSdkVersion 14
@@ -24,9 +24,9 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.0.0'
-    compile 'com.android.support:support-v4:25.0.0'
-    compile 'com.android.support:design:25.0.0'
+    compile 'com.android.support:appcompat-v7:25.0.1'
+    compile 'com.android.support:support-v4:25.0.1'
+    compile 'com.android.support:design:25.0.1'
 }
 
 publish {

--- a/spacelib/src/main/java/com/luseen/spacenavigation/SpaceNavigationView.java
+++ b/spacelib/src/main/java/com/luseen/spacenavigation/SpaceNavigationView.java
@@ -97,6 +97,8 @@ public class SpaceNavigationView extends RelativeLayout {
 
     private int inActiveCentreButtonIconColor = NOT_DEFINED;
 
+    private int activeCentreButtonBackgroundColor = NOT_DEFINED;
+
     private int centreButtonIcon = NOT_DEFINED;
 
     private int activeSpaceItemColor = NOT_DEFINED;
@@ -159,6 +161,7 @@ public class SpaceNavigationView extends RelativeLayout {
             centreButtonIcon = typedArray.getResourceId(R.styleable.SpaceNavigationView_centre_button_icon, R.drawable.near_me);
             activeCentreButtonIconColor = typedArray.getColor(R.styleable.SpaceNavigationView_active_centre_button_icon_color, resources.getColor(R.color.space_white));
             inActiveCentreButtonIconColor = typedArray.getColor(R.styleable.SpaceNavigationView_inactive_centre_button_icon_color, resources.getColor(com.luseen.spacenavigation.R.color.default_inactive_item_color));
+            activeCentreButtonBackgroundColor = typedArray.getColor(R.styleable.SpaceNavigationView_active_centre_button_background_color, resources.getColor(com.luseen.spacenavigation.R.color.centre_button_color));
 
             typedArray.recycle();
         }
@@ -528,16 +531,26 @@ public class SpaceNavigationView extends RelativeLayout {
              * Selects the centre button as current
              */
             if (selectedIndex == -1) {
-                if (centreButton != null)
+                if (centreButton != null) {
                     centreButton.getDrawable().setColorFilter(activeCentreButtonIconColor, PorterDuff.Mode.SRC_IN);
+
+                    if (activeCentreButtonBackgroundColor != NOT_DEFINED) {
+                        centreButton.setBackgroundTintList(ColorStateList.valueOf(activeCentreButtonBackgroundColor));
+                    }
+                }
             }
 
             /**
              * Removes selection from centre button
              */
             if (currentSelectedItem == -1) {
-                if (centreButton != null)
+                if (centreButton != null) {
                     centreButton.getDrawable().setColorFilter(inActiveCentreButtonIconColor, PorterDuff.Mode.SRC_IN);
+
+                    if (activeCentreButtonBackgroundColor != NOT_DEFINED) {
+                        centreButton.setBackgroundTintList(ColorStateList.valueOf(centreButtonColor));
+                    }
+                }
             }
         }
 
@@ -738,6 +751,15 @@ public class SpaceNavigationView extends RelativeLayout {
      */
     public void setCentreButtonIcon(int centreButtonIcon) {
         this.centreButtonIcon = centreButtonIcon;
+    }
+
+    /**
+     * Set active centre button color
+     *
+     * @param activeCentreButtonBackgroundColor color to change
+     */
+    public void setActiveCentreButtonBackgroundColor(@ColorInt int activeCentreButtonBackgroundColor) {
+        this.activeCentreButtonBackgroundColor = activeCentreButtonBackgroundColor;
     }
 
     /**

--- a/spacelib/src/main/res/values/attrs.xml
+++ b/spacelib/src/main/res/values/attrs.xml
@@ -12,6 +12,7 @@
         <attr name="centre_button_icon" format="reference" />
         <attr name="active_centre_button_icon_color" format="color" />
         <attr name="inactive_centre_button_icon_color" format="color" />
+        <attr name="active_centre_button_background_color" format="color"/>
     </declare-styleable>
 
 </resources>

--- a/spacelib/src/main/res/values/attrs.xml
+++ b/spacelib/src/main/res/values/attrs.xml
@@ -10,7 +10,8 @@
         <attr name="active_item_color" format="color" />
         <attr name="inactive_item_color" format="color" />
         <attr name="centre_button_icon" format="reference" />
-        <attr name="centre_button_icon_color" format="color" />
+        <attr name="active_centre_button_icon_color" format="color" />
+        <attr name="inactive_centre_button_icon_color" format="color" />
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
Added a method to select the centre button behavior (setCentreButtonSelectable) and also a method to set the centre button explicitly (setCentreButtonSelected).
A breaking change is the removing of  centre_button_icon_color and adding of active_centre_button_icon_color and inactive_centre_button_icon_color instead.

Hope it fulfills your expectations ;)