### PR TITLE
Fix inActiveCentreButtonIconColor not being used initially

### DIFF
--- a/spacelib/src/main/java/com/luseen/spacenavigation/SpaceNavigationView.java
+++ b/spacelib/src/main/java/com/luseen/spacenavigation/SpaceNavigationView.java
@@ -283,7 +283,7 @@ public class SpaceNavigationView extends RelativeLayout {
         centreButton.setImageResource(centreButtonIcon);
 
         if (isCentreButtonIconColorFilterEnabled || isCentreButtonSelectable)
-            centreButton.getDrawable().setColorFilter(inActiveSpaceItemColor, PorterDuff.Mode.SRC_IN);
+            centreButton.getDrawable().setColorFilter(inActiveCentreButtonIconColor, PorterDuff.Mode.SRC_IN);
 
         centreButton.setOnClickListener(new OnClickListener() {
             @Override


### PR DESCRIPTION
Thanks for the nice library :)

I couldn't get `inActiveCentreButtonIconColor` to work when the view is first created. From looking at the code when the centre button is deselected, it looks like this fix should be ok?