### PR TITLE
Fix badge trimming of second icon

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,7 +3,9 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/Sample/Sample.iml" filepath="$PROJECT_DIR$/Sample/Sample.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Sample/Sample.iml" filepath="$PROJECT_DIR$/Sample/Sample.iml" />
       <module fileurl="file://$PROJECT_DIR$/Space-Navigation-View.iml" filepath="$PROJECT_DIR$/Space-Navigation-View.iml" />
+      <module fileurl="file://$PROJECT_DIR$/spacelib/spacelib.iml" filepath="$PROJECT_DIR$/spacelib/spacelib.iml" />
       <module fileurl="file://$PROJECT_DIR$/spacelib/spacelib.iml" filepath="$PROJECT_DIR$/spacelib/spacelib.iml" />
     </modules>
   </component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Sample/src/main/AndroidManifest.xml
+++ b/Sample/src/main/AndroidManifest.xml
@@ -15,6 +15,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity android:name=".ActivityWithBadge"></activity>
     </application>
 
 </manifest>

--- a/Sample/src/main/java/com/luseen/spacenavigationview/ActivityWithBadge.java
+++ b/Sample/src/main/java/com/luseen/spacenavigationview/ActivityWithBadge.java
@@ -1,6 +1,5 @@
 package com.luseen.spacenavigationview;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
@@ -18,7 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 
-public class MainActivity extends AppCompatActivity {
+public class ActivityWithBadge extends AppCompatActivity {
 
     private SpaceNavigationView spaceNavigationView;
 
@@ -27,13 +26,13 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        Toast.makeText(getApplicationContext(), "Long press center button to show badge example", Toast.LENGTH_LONG).show();
-
         spaceNavigationView = (SpaceNavigationView) findViewById(R.id.space);
         spaceNavigationView.initWithSaveInstanceState(savedInstanceState);
         spaceNavigationView.addSpaceItem(new SpaceItem("HOME", R.drawable.account));
         spaceNavigationView.addSpaceItem(new SpaceItem("SEARCH", R.drawable.magnify));
-        spaceNavigationView.shouldShowFullBadgeText(true);
+        spaceNavigationView.addSpaceItem(new SpaceItem("HOME", R.drawable.account));
+        spaceNavigationView.addSpaceItem(new SpaceItem("SEARCH", R.drawable.magnify));
+        spaceNavigationView.shouldShowFullBadgeText(false);
         spaceNavigationView.setCentreButtonIconColorFilterEnabled(false);
 
         spaceNavigationView.setSpaceOnClickListener(new SpaceOnClickListener() {
@@ -41,6 +40,8 @@ public class MainActivity extends AppCompatActivity {
             public void onCentreButtonClick() {
                 Log.d("onCentreButtonClick ", "onCentreButtonClick");
                 spaceNavigationView.shouldShowFullBadgeText(true);
+                spaceNavigationView.showBadgeAtIndex(1, 23, getResources().getColor(R.color.colorPrimary));
+                spaceNavigationView.showBadgeAtIndex(2, 23, getResources().getColor(R.color.colorPrimary));
             }
 
             @Override
@@ -57,17 +58,15 @@ public class MainActivity extends AppCompatActivity {
         spaceNavigationView.setSpaceOnLongClickListener(new SpaceOnLongClickListener() {
             @Override
             public void onCentreButtonLongClick() {
-//                Toast.makeText(MainActivity.this, "onCentreButtonLongClick", Toast.LENGTH_SHORT).show();
-                Intent intent = new Intent(MainActivity.this, ActivityWithBadge.class);
-                startActivity(intent);
+                Toast.makeText(ActivityWithBadge.this, "onCentreButtonLongClick", Toast.LENGTH_SHORT).show();
             }
 
             @Override
             public void onItemLongClick(int itemIndex, String itemName) {
-                Toast.makeText(MainActivity.this, itemIndex + " " + itemName, Toast.LENGTH_SHORT).show();
+                Toast.makeText(ActivityWithBadge.this, itemIndex + " " + itemName, Toast.LENGTH_SHORT).show();
             }
         });
-
+        spaceNavigationView.showIconOnly();
         setUpRecyclerView();
     }
 
@@ -87,7 +86,7 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onClick(int position) {
                 if (position == 0) {
-                    spaceNavigationView.showBadgeAtIndex(1, 54, ContextCompat.getColor(MainActivity.this, R.color.badge_background_color));
+                    spaceNavigationView.showBadgeAtIndex(1, 54, ContextCompat.getColor(ActivityWithBadge.this, R.color.badge_background_color));
                 } else if (position == 1) {
                     spaceNavigationView.hideBudgeAtIndex(1);
                 }

--- a/Sample/src/main/java/com/luseen/spacenavigationview/ActivityWithBadge.java
+++ b/Sample/src/main/java/com/luseen/spacenavigationview/ActivityWithBadge.java
@@ -1,11 +1,14 @@
 package com.luseen.spacenavigationview;
 
+import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
+import android.view.View;
+import android.widget.Button;
 import android.widget.Toast;
 
 import com.luseen.spacenavigation.SpaceItem;
@@ -24,7 +27,19 @@ public class ActivityWithBadge extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+        setContentView(R.layout.activity_badge);
+
+        Button btnShowBadge = (Button) findViewById(R.id.btnBadge);
+        btnShowBadge.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                spaceNavigationView.shouldShowFullBadgeText(true);
+                spaceNavigationView.showBadgeAtIndex(0, 2, Color.RED);
+                spaceNavigationView.showBadgeAtIndex(1, 3, Color.CYAN);
+                spaceNavigationView.showBadgeAtIndex(2, 4, Color.MAGENTA);
+                spaceNavigationView.showBadgeAtIndex(3, 23, Color.BLUE);
+            }
+        });
 
         spaceNavigationView = (SpaceNavigationView) findViewById(R.id.space);
         spaceNavigationView.initWithSaveInstanceState(savedInstanceState);
@@ -39,9 +54,6 @@ public class ActivityWithBadge extends AppCompatActivity {
             @Override
             public void onCentreButtonClick() {
                 Log.d("onCentreButtonClick ", "onCentreButtonClick");
-                spaceNavigationView.shouldShowFullBadgeText(true);
-                spaceNavigationView.showBadgeAtIndex(1, 23, getResources().getColor(R.color.colorPrimary));
-                spaceNavigationView.showBadgeAtIndex(2, 23, getResources().getColor(R.color.colorPrimary));
             }
 
             @Override

--- a/Sample/src/main/res/layout/activity_badge.xml
+++ b/Sample/src/main/res/layout/activity_badge.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main_content"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.luseen.spacenavigationview.MainActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="20dp"
+            android:text="This library doesn't support loading of badges during initialisation. It takes some time for bottom navigation to get initialize. Hence I have given a button below to load badges on click. In production you can call the showBadgeAtIndex method after a network call or use it by making a thread call of 3 second" />
+
+        <Button
+            android:id="@+id/btnBadge"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Click to Show Badge" />
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/recyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+            <com.luseen.spacenavigation.SpaceNavigationView
+                android:id="@+id/space"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:layout_gravity="bottom"
+                app:centre_part_linear="true"
+                app:layout_behavior="com.luseen.spacenavigation.SpaceNavigationViewBehavior" />
+        </RelativeLayout>
+    </LinearLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta3'
-        classpath 'com.novoda:bintray-release:0.3.4'
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.novoda:bintray-release:0.8.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jan 29 18:23:19 AMT 2017
+#Wed Mar 14 18:44:51 IST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/spacelib/src/main/res/drawable/near_me.xml
+++ b/spacelib/src/main/res/drawable/near_me.xml
@@ -4,5 +4,5 @@
     android:width="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-    <path android:fillColor="#fff" android:pathData="M21,3L3,10.53V11.5L9.84,14.16L12.5,21H13.46L21,3Z" />
+    <path android:fillColor="#ff0000" android:pathData="M21,3L3,10.53V11.5L9.84,14.16L12.5,21H13.46L21,3Z" />
 </vector>

--- a/spacelib/src/main/res/layout/space_item_view.xml
+++ b/spacelib/src/main/res/layout/space_item_view.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -16,7 +17,9 @@
         <ImageView
             android:id="@+id/space_icon"
             android:layout_width="@dimen/space_item_icon_default_size"
-            android:layout_height="@dimen/space_item_icon_default_size" />
+            android:layout_height="@dimen/space_item_icon_default_size"
+            android:layout_gravity="center"
+            app:srcCompat="@drawable/near_me" />
 
         <TextView
             android:id="@+id/space_text"
@@ -26,6 +29,7 @@
             android:layout_marginLeft="10dp"
             android:lines="1"
             android:textSize="@dimen/space_item_text_default_size"
+            android:visibility="gone"
             tools:text="Label One" />
     </LinearLayout>
 
@@ -34,11 +38,11 @@
         android:layout_width="16dp"
         android:layout_height="16dp"
         android:layout_alignParentTop="true"
-        android:layout_marginLeft="@dimen/badge_left_margin"
-        android:layout_marginRight="2dp"
+        android:layout_marginLeft="0dp"
+
         android:layout_marginTop="3dp"
         android:layout_toRightOf="@+id/main_content"
-        android:visibility="gone">
+        android:visibility="visible">
 
         <TextView
             android:id="@+id/badge_text_view"

--- a/spacelib/src/main/res/layout/space_item_view.xml
+++ b/spacelib/src/main/res/layout/space_item_view.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -17,9 +16,7 @@
         <ImageView
             android:id="@+id/space_icon"
             android:layout_width="@dimen/space_item_icon_default_size"
-            android:layout_height="@dimen/space_item_icon_default_size"
-            android:layout_gravity="center"
-            app:srcCompat="@drawable/near_me" />
+            android:layout_height="@dimen/space_item_icon_default_size" />
 
         <TextView
             android:id="@+id/space_text"
@@ -29,7 +26,6 @@
             android:layout_marginLeft="10dp"
             android:lines="1"
             android:textSize="@dimen/space_item_text_default_size"
-            android:visibility="gone"
             tools:text="Label One" />
     </LinearLayout>
 
@@ -38,11 +34,11 @@
         android:layout_width="16dp"
         android:layout_height="16dp"
         android:layout_alignParentTop="true"
-        android:layout_marginLeft="0dp"
-
+        android:layout_marginLeft="@dimen/badge_left_margin"
+        android:layout_marginRight="2dp"
         android:layout_marginTop="3dp"
         android:layout_toRightOf="@+id/main_content"
-        android:visibility="visible">
+        android:visibility="gone">
 
         <TextView
             android:id="@+id/badge_text_view"

--- a/spacelib/src/main/res/values/dimens.xml
+++ b/spacelib/src/main/res/values/dimens.xml
@@ -3,7 +3,7 @@
     <dimen name="main_content_height">50dp</dimen>
     <dimen name="space_centre_button_default_size">56dp</dimen>
     <dimen name="space_centre_button_margin">6dp</dimen>
-    <dimen name="centre_content_width">110dp</dimen>
+    <dimen name="centre_content_width">80dp</dimen>
     <dimen name="space_item_icon_default_size">18dp</dimen>
     <dimen name="space_item_icon_only_size">25dp</dimen>
     <dimen name="space_item_text_default_size">14sp</dimen>


### PR DESCRIPTION
When you add 4 icons in bottom navigation and set badges on second icon (which is left to center icon), the badge text gets trim due to the padding assigned to center button. This update fixes that issue.
This update also adds another screen on sample project to demonstrate how badge can be assigned to the icons.
Irrespective of interest Gradle has been updated as well to version 4.1 to make the compilation successful.

Please merge to main repository and update the dependency version.